### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -1,8 +1,9 @@
 # Ref: https://securitylab.github.com/research/github-actions-preventing-pwn-requests
 name: Breakage
+permissions:
+  contents: read
+  pull-requests: write
 
-# read-only repo token
-# no access to secrets
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/arnavk23/CUTEst.jl/security/code-scanning/8](https://github.com/arnavk23/CUTEst.jl/security/code-scanning/8)

To fix the issue, we need to explicitly define the permissions block at the root of the workflow. This ensures that the workflow adheres to the principle of least privilege by limiting the `GITHUB_TOKEN` permissions to only what is necessary. Specifically, for this workflow, we need `contents: read` and `pull-requests: write` permissions, as it involves commenting on pull requests and managing content. The permissions block will be added at the top level of the workflow, applicable to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
